### PR TITLE
Prevent NavigationDrawer from showing on mobile.

### DIFF
--- a/apps/admin-portal/src/app/layout.tsx
+++ b/apps/admin-portal/src/app/layout.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import React from 'react';
 import NavigationDrawer from '@/components/NavigationDrawer';
 import HeaderBar from '@/components/Appbar';

--- a/apps/admin-portal/src/components/NavigationDrawer/index.tsx
+++ b/apps/admin-portal/src/components/NavigationDrawer/index.tsx
@@ -1,16 +1,22 @@
+'use client';
+
 import React from 'react';
 // MUI
 import Drawer from '@mui/material/Drawer';
 import { Box } from '@mui/system';
 import NavigationDrawerItem from './NavigationDrawerItem';
+import { useMediaQuery, useTheme } from '@mui/material';
 
 export default function NavigationDrawer() {
   const drawerWidth = 280;
+  const theme = useTheme();
+  const isNotMobile = useMediaQuery(theme.breakpoints.up('sm'));
 
   // Setting up Drawer
   return (
     <Drawer
-      variant="permanent"
+      variant={isNotMobile ? 'permanent' : 'temporary'}
+      open={isNotMobile}
       sx={{
         width: drawerWidth,
         flexShrink: 0,
@@ -20,7 +26,6 @@ export default function NavigationDrawer() {
           boxSizing: 'border-box',
         },
       }}
-      open={true}
     >
       <Box sx={{ width: drawerWidth }}>
         <Box

--- a/apps/admin-portal/src/components/NavigationDrawer/index.tsx
+++ b/apps/admin-portal/src/components/NavigationDrawer/index.tsx
@@ -10,13 +10,13 @@ import { useMediaQuery, useTheme } from '@mui/material';
 export default function NavigationDrawer() {
   const drawerWidth = 280;
   const theme = useTheme();
-  const isNotMobile = useMediaQuery(theme.breakpoints.up('sm'));
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
   // Setting up Drawer
   return (
     <Drawer
-      variant={isNotMobile ? 'permanent' : 'temporary'}
-      open={isNotMobile}
+      variant={isMobile ? 'permanent' : 'temporary'}
+      open={isMobile}
       sx={{
         width: drawerWidth,
         flexShrink: 0,


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes. Please also include relevant motivation and context. -->

Edited the NavigationDrawer to only display when on mobile by creating a variant in index.tsx.

## Relevant issue(s)

<!-- List the issues related to this PR here in the format "#[ISSUE NUMBER]". Ideally, there should only be one issue per PR. -->
<!-- For example:
- #1 #168
- #2
 -->

## Questions
<!-- Please note any questions or concerns about this PR here, or specific areas you would like reviewers to pay special attention to -->

I had to remove "use client"; in layout.tsx, the program would not compile and Zavier told me to move it into the index file

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have assigned reviewers to this PR
