### PR TITLE
168 only show appbar on mobile

### DIFF
--- a/apps/admin-portal/src/components/Appbar/index.tsx
+++ b/apps/admin-portal/src/components/Appbar/index.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import * as React from 'react';
 import AppBar from '@mui/material/AppBar';
 import Box from '@mui/material/Box';
@@ -13,6 +14,7 @@ import Button from '@mui/material/Button';
 import Tooltip from '@mui/material/Tooltip';
 import MenuItem from '@mui/material/MenuItem';
 import AdbIcon from '@mui/icons-material/Adb';
+import { useMediaQuery, useTheme } from '@mui/material';
 
 export default function HeaderBar() {
   const pages = ['Home', 'Projects'];
@@ -40,108 +42,122 @@ export default function HeaderBar() {
     setAnchorElUser(null);
   };
 
-  return (
-    <AppBar position="absolute" color="transparent">
-      <Container maxWidth="xl">
-        <Toolbar disableGutters>
-          <Typography
-            variant="h6"
-            noWrap
-            component="a"
-            href="#app-bar-with-responsive-menu"
-            sx={{
-              mr: 2,
-              display: { xs: 'none', md: 'flex' },
-              fontFamily: 'monospace',
-              fontWeight: 700,
-              letterSpacing: '.3rem',
-              color: 'inherit',
-              textDecoration: 'none',
-            }}
-          >
-            Hack4Impact Admin Portal
-          </Typography>
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.down('sm'));
 
-          <Box sx={{ flexGrow: 1, display: { xs: 'flex', md: 'none' } }}>
-            <IconButton
-              size="large"
-              aria-label="account of current user"
-              aria-controls="menu-appbar"
-              aria-haspopup="true"
-              onClick={handleOpenNavMenu}
-              color="inherit"
-            >
-              <MenuIcon />
-            </IconButton>
-            <Menu
-              id="menu-appbar"
-              anchorEl={anchorElNav}
-              anchorOrigin={{
-                vertical: 'bottom',
-                horizontal: 'left',
-              }}
-              keepMounted
-              transformOrigin={{
-                vertical: 'top',
-                horizontal: 'left',
-              }}
-              open={Boolean(anchorElNav)}
-              onClose={handleCloseNavMenu}
+  //render AppBar only if isMobile is true
+  if (!isMobile) {
+    return null;
+  } else
+    return (
+      <AppBar position="absolute" color="transparent">
+        <Container maxWidth="xl">
+          <Toolbar disableGutters>
+            <Typography
+              variant="h6"
+              noWrap
+              component="a"
+              href="#app-bar-with-responsive-menu"
               sx={{
-                display: { xs: 'block', md: 'none' },
+                mr: 2,
+                display: 'flex',
+                alignItems: 'center',
+                flexDirection: 'column',
+                fontFamily: 'monospace',
+                fontWeight: 600,
+                letterSpacing: '.3rem',
+                fontSize: '1rem',
+                color: 'inherit',
+                textDecoration: 'none',
               }}
             >
-              {pages.map((page) => (
-                <MenuItem key={page} onClick={handleCloseNavMenu}>
-                  <Typography textAlign="center">{page}</Typography>
-                </MenuItem>
-              ))}
-            </Menu>
-          </Box>
-          <AdbIcon sx={{ display: { xs: 'flex', md: 'none' }, mr: 1 }} />
-          <Box sx={{ flexGrow: 1, display: { xs: 'none', md: 'flex' } }}>
-            {pages.map((page) => (
-              <Button
-                key={page}
-                onClick={handleCloseNavMenu}
-                sx={{ my: 2, color: 'black', display: 'block' }}
-              >
-                {page}
-              </Button>
-            ))}
-          </Box>
+              <span>Hack4Impact</span>
+              <span>Admin Portal</span>{' '}
+            </Typography>
 
-          <Box sx={{ flexGrow: 0 }}>
-            <Tooltip title="Open settings">
-              <IconButton onClick={handleOpenUserMenu} sx={{ p: 0 }}>
-                <Avatar alt="Remy Sharp" src="/static/images/avatar/2.jpg" />
-              </IconButton>
-            </Tooltip>
-            <Menu
-              sx={{ mt: '45px' }}
-              id="menu-appbar"
-              anchorEl={anchorElUser}
-              anchorOrigin={{
-                vertical: 'top',
-                horizontal: 'right',
-              }}
-              keepMounted
-              transformOrigin={{
-                vertical: 'top',
-                horizontal: 'right',
-              }}
-              open={Boolean(anchorElUser)}
-              onClose={handleCloseUserMenu}
+            <Box
+              sx={{ flexGrow: 1, display: 'flex', justifyContent: 'flex-end' }}
             >
-              {settings.map((setting) => (
-                <MenuItem key={setting} onClick={handleCloseUserMenu}>
-                  <Typography textAlign="center">{setting}</Typography>
-                </MenuItem>
+              <IconButton
+                size="large"
+                aria-label="account of current user"
+                aria-controls="menu-appbar"
+                aria-haspopup="true"
+                onClick={handleOpenNavMenu}
+                color="inherit"
+                sx={{ marginLeft: '10px' }}
+              >
+                <MenuIcon />
+              </IconButton>
+              <Menu
+                id="menu-appbar"
+                anchorEl={anchorElNav}
+                anchorOrigin={{
+                  vertical: 'bottom',
+                  horizontal: 'left',
+                }}
+                keepMounted
+                transformOrigin={{
+                  vertical: 'top',
+                  horizontal: 'left',
+                }}
+                open={Boolean(anchorElNav)}
+                onClose={handleCloseNavMenu}
+                sx={{
+                  display: { xs: 'block', md: 'none' },
+                }}
+              >
+                {pages.map((page) => (
+                  <MenuItem key={page} onClick={handleCloseNavMenu}>
+                    <Typography textAlign="center">{page}</Typography>
+                  </MenuItem>
+                ))}
+              </Menu>
+            </Box>
+            <AdbIcon sx={{ display: { xs: 'flex', md: 'none' }, mr: 1 }} />
+            <Box sx={{ flexGrow: 1, display: { xs: 'none', md: 'flex' } }}>
+              {pages.map((page) => (
+                <Button
+                  key={page}
+                  onClick={handleCloseNavMenu}
+                  sx={{ my: 2, color: 'black', display: 'block' }}
+                >
+                  {page}
+                </Button>
               ))}
-            </Menu>
-          </Box>
-        </Toolbar>
-      </Container>
-    </AppBar>
-  );
+            </Box>
+
+            <Box sx={{ flexGrow: 0 }}>
+              <Tooltip title="Open settings">
+                <IconButton onClick={handleOpenUserMenu} sx={{ p: 0 }}>
+                  <Avatar alt="Remy Sharp" src="/static/images/avatar/2.jpg" />
+                </IconButton>
+              </Tooltip>
+              <Menu
+                sx={{ mt: '45px' }}
+                id="menu-appbar"
+                anchorEl={anchorElUser}
+                anchorOrigin={{
+                  vertical: 'top',
+                  horizontal: 'right',
+                }}
+                keepMounted
+                transformOrigin={{
+                  vertical: 'top',
+                  horizontal: 'right',
+                }}
+                open={Boolean(anchorElUser)}
+                onClose={handleCloseUserMenu}
+              >
+                {settings.map((setting) => (
+                  <MenuItem key={setting} onClick={handleCloseUserMenu}>
+                    <Typography textAlign="center">{setting}</Typography>
+                  </MenuItem>
+                ))}
+              </Menu>
+            </Box>
+          </Toolbar>
+        </Container>
+      </AppBar>
+    );
 }

--- a/packages/internal-models/src/db/models/Applicant.ts
+++ b/packages/internal-models/src/db/models/Applicant.ts
@@ -22,22 +22,6 @@ const ApplicantSchema = new Schema({
     type: String,
     required: true,
   },
-  referrer: {
-    type: String,
-    required: false,
-  },
-  major: {
-    type: String,
-    required: true,
-  },
-  expectedGraduation: {
-    type: String,
-    required: true,
-  },
-  linkedinUrl: {
-    type: String,
-    required: false,
-  },
   status: {
     type: String,
     enum: applicantStatuses,
@@ -60,7 +44,7 @@ const ApplicantSchema = new Schema({
     enum: applicantDecisions,
     required: false,
   },
-  resumeUrl: {
+  decisionReason: {
     type: String,
     required: false,
   },
@@ -80,8 +64,8 @@ const ApplicantSchema = new Schema({
   },
   statusUpdatedAt: {
     type: Date,
-    required: false
-  }
+    required: false,
+  },
 });
 
 export type ApplicantDocument = Omit<ApplicantEntity, '_id'> & Document;

--- a/packages/internal-models/src/types/applicant.ts
+++ b/packages/internal-models/src/types/applicant.ts
@@ -16,7 +16,7 @@ export type ApplicantStatus = z.infer<typeof zApplicantStatus>;
 export const applicantDecisions = [
   'Accepted',
   'Waitlisted',
-  'Rejected'
+  'Rejected',
 ] as const;
 export const zApplicantDecision = z.enum(applicantDecisions);
 export type ApplicantDecision = z.infer<typeof zApplicantDecision>;
@@ -26,16 +26,12 @@ const zApplicant = z.object({
   lastName: z.string(),
   netid: z.string(),
   term: zTerm,
-  referrer: z.string().optional(),
-  major: z.string(),
-  expectedGraduation: zTerm,
-  linkedinUrl: z.string().url().optional(),
   status: zApplicantStatus,
   interviewTime: z.date().optional(),
   interviewMeetingLink: z.string().url().optional(),
   noShowCount: z.number().optional(),
   decision: zApplicantDecision.optional(),
-  resumeUrl: z.string().url().optional(),
+  decisionReason: z.string().optional(),
   notes: z.string().optional(),
   application: zFormSubmission, // TODO: figure out verification
   evaluation: zFormSubmission.optional(),


### PR DESCRIPTION
# Description
<!-- Please include a summary of the changes. Please also include relevant motivation and context. -->
Created media query condition that only displays the App Bar on mobile, and restored the logo and other menu items on mobile display.

## Relevant issue(s)

<!-- List the issues related to this PR here in the format "#[ISSUE NUMBER]". Ideally, there should only be one issue per PR. -->
<!-- For example:
- #1
- #2
 -->

#168 

## Questions
<!-- Please note any questions or concerns about this PR here, or specific areas you would like reviewers to pay special attention to -->

The edits to layout.tsx and navigationDrawer are not relevant to this PR, only those in the appbar are (i cant figure out how to remove those changes)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have assigned reviewers to this PR
