### PR TITLE
Create Right Filter on History Page

### DIFF
--- a/apps/applicant-tracking/src/components/HistoryRightFilter.tsx
+++ b/apps/applicant-tracking/src/components/HistoryRightFilter.tsx
@@ -1,0 +1,36 @@
+'use client'
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import InputLabel from '@mui/material/InputLabel';
+import MenuItem from '@mui/material/MenuItem';
+import FormControl from '@mui/material/FormControl';
+import Select, { SelectChangeEvent } from '@mui/material/Select';
+
+export default function BasicSelect() {
+  const [date, setDate] = React.useState('');
+
+  const handleChange = (event: SelectChangeEvent) => {
+    setDate(event.target.value as string);
+  };
+
+  return (
+    <Box sx={{ width: '140px'}}>
+      <FormControl fullWidth>
+        <InputLabel id="HistoryRightFilterLabel">End Date</InputLabel>
+        <Select
+          labelId="HistoryRightFilterLabel"
+          id="HistoryRightFilter"
+          value={date}
+          label="End Date"
+          onChange={handleChange}
+        >
+          {/* For the values, the first 4 digits are the year, and
+          the end digit 0=fall semester or 1=spring semester */}
+          <MenuItem value={20230}>Fall 2023</MenuItem>
+          <MenuItem value={20241}>Spring 2024</MenuItem>
+          <MenuItem value={20240}>Fall 2024</MenuItem>
+        </Select>
+      </FormControl>
+    </Box>
+  );
+}


### PR DESCRIPTION
# Description
I added a dropdown component that acts as the end date for a date filter on the applicant history page. 

## Relevant issue(s)
- #253 


## Questions
- I wasn't sure about styling or where to place the component, as I couldn't find the "History Page" to import the component to. 

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have assigned reviewers to this PR
