### PR TITLE
Styling teams page and adding teammate bar

### DIFF
--- a/apps/applicant-tracking/package.json
+++ b/apps/applicant-tracking/package.json
@@ -11,6 +11,8 @@
   },
   "dependencies": {
     "@mui/x-charts": "7.28.0",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/utilities": "^3.2.2",
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
     "@hack4impact-utk/internal-models": "file:../../packages/internal-models",

--- a/apps/applicant-tracking/src/app/applicants/teams/page.tsx
+++ b/apps/applicant-tracking/src/app/applicants/teams/page.tsx
@@ -1,0 +1,81 @@
+'use client'
+import Typography from '@mui/material/Typography';
+import React, { useState } from 'react';
+import { DndContext, useSensors, PointerSensor, useSensor } from '@dnd-kit/core';
+import Box from '@mui/material/Box';
+import { TeamList } from '@/components/TeamList';
+
+interface Member {
+    id: string;
+    name?: string;
+    experience?: string;
+    team?: string;
+}
+
+// Member data should be imported in this format. ID can eventually be dynamically assigned on import
+
+let members: Member[] = [
+    {id:'1', name:'Dr. Marz', experience:'Professor', team:'applicants'}, 
+    {id:'2', name:'Dr. Gregor', experience:'Professor', team:'applicants'},
+    {id:'3', name:'Dr. Plank', experience:'Professor', team:'applicants'},
+    {id:'4', name:'Dr. Emrich', experience:'Professor', team:'applicants'},
+    {id:'5', name:'Dr. Crumpton', experience:'Professor', team:'team1'},
+]
+
+export default function TeamsPage() {
+    const [items, setItems] = useState(members)
+
+    const sensors = useSensors(
+        useSensor(PointerSensor),
+    )
+
+    const [parent, setParent] = useState(null);
+
+    return (
+    <>
+    <Typography variant='h4' align='center' style={{padding: '10px'}}>LBP Teams</Typography>
+    <Box sx={{ width: '95%', height: 5, bgcolor: 'orange', margin: 'auto'}} />
+    <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
+        <div style={{display: 'flex', flexDirection:'row', flexWrap:'wrap', gap:'100px'}}>        
+            <TeamList id="applicants" title="Applicants" members={items.filter(function(obj) {return obj.team === 'applicants'})}/>
+            <div style={{display: 'flex', flexDirection:'row', flexWrap:'wrap'}}>
+                <TeamList id='team1' title='Team 1' members={items.filter(function(obj) {return obj.team === 'team1'})}/>
+                <TeamList id='team2' title='Team 2' members={items.filter(function(obj) {return obj.team === 'team2'})}/>
+            </div>
+        </div>
+    </DndContext>
+    </>
+    );
+
+    /* Eventually use this instead
+
+    function changeTeam(mem: Member, newteam: string) {
+        let newmem: Member = {
+            id: mem.id,
+            name: mem.name,
+            experience: mem.experience,
+            team: newteam
+        }
+        setItems([...members.filter(function(obj){return obj.id != mem.id}), newmem])
+    }
+    */
+
+    function handleDragEnd(event: any) {
+        const {active, over} = event;
+
+        let mem: Member ={
+            id: active.id,
+            name: active.name,
+            experience: active.experience,
+            team: active.team
+        }
+        let index = items.findIndex(item => item.id === active.id)
+        if(index != -1)
+        {
+            //changeTeam(mem, over.id); <--- Eventually use this instead of next line. better for dynamic updates
+            items[index].team = over.id;
+            setParent(over ? over.id : null);
+        }
+    }
+
+}

--- a/apps/applicant-tracking/src/app/applicants/teams/page.tsx
+++ b/apps/applicant-tracking/src/app/applicants/teams/page.tsx
@@ -36,7 +36,7 @@ export default function TeamsPage() {
     <Typography variant='h4' align='center' style={{padding: '10px'}}>LBP Teams</Typography>
     <Box sx={{ width: '95%', height: 5, bgcolor: 'orange', margin: 'auto'}} />
     <DndContext sensors={sensors} onDragEnd={handleDragEnd}>
-        <div style={{display: 'flex', flexDirection:'row', flexWrap:'wrap', gap:'100px'}}>        
+        <div style={{display: 'flex', flexDirection:'row', flexWrap:'wrap', gap:'50px'}}>        
             <TeamList id="applicants" title="Applicants" members={items.filter(function(obj) {return obj.team === 'applicants'})}/>
             <div style={{display: 'flex', flexDirection:'row', flexWrap:'wrap'}}>
                 <TeamList id='team1' title='Team 1' members={items.filter(function(obj) {return obj.team === 'team1'})}/>

--- a/apps/applicant-tracking/src/components/TeamList/TeamItem/index.tsx
+++ b/apps/applicant-tracking/src/components/TeamList/TeamItem/index.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { useDraggable } from "@dnd-kit/core";
+import { Box, Typography } from '@mui/material';
+
+interface Member {
+    id: string;
+    name?: string;
+    experience?: string;
+    team?: string;
+}
+
+// These are the member boxes that you drag onto the droppable environments
+
+
+export function TeamItem(props: Member) {
+    const {attributes, listeners, setNodeRef, transform} = useDraggable({id: props.id})
+    const teamId = props.team;
+    const movement = transform ? {
+        transform: `translate3d(${transform.x}px, ${transform.y}px, 0)`,
+    } : undefined;
+
+    const styling = {
+        display: 'flex', justifyContent: 'left', alignItems: 'left', flexDirection:'column',
+        border: '1px solid black', bgcolor:'#b6d5b8',
+        width: 290, height: 50,
+    }
+
+    return (
+        <div ref={setNodeRef} style={movement} {...attributes} {...listeners}>
+            <Box ref={setNodeRef} sx ={styling}>
+                <Typography variant='body1' style={{paddingLeft: '5px'}}>Name: {props.name}</Typography>
+                <Typography variant='body1' style={{paddingLeft: '5px'}}>Experience: {props.experience}</Typography>
+            </Box>
+        </div>
+
+    );
+}

--- a/apps/applicant-tracking/src/components/TeamList/index.tsx
+++ b/apps/applicant-tracking/src/components/TeamList/index.tsx
@@ -1,0 +1,42 @@
+import React, { ReactNode, useState } from 'react';
+import { useDroppable } from "@dnd-kit/core";
+import { Box, Typography } from '@mui/material';
+import { TeamItem } from './TeamItem';
+
+interface Member {
+    id: string;
+    name?: string;
+    experience?: string;
+    team?: string;
+}
+
+interface TeamListProperties{
+    id: string;
+    title?: string;
+    children?: ReactNode;
+    members: Member[];
+}
+
+//These are the droppable environments that you can drag members into
+
+
+export function TeamList (props: TeamListProperties){
+    const {setNodeRef} = useDroppable({id: props.id})
+
+    const styling = {
+        display: 'flex', justifyContent: 'top center', alignItems: 'center', flexDirection:'column',
+        borderRadius: 2, border: '1px solid black',
+        width: 300, margin:'10px'
+    }
+
+    const [tall, setTall] = useState(50); //eventually useful if height of the boxes need to be dynamic
+
+    return (
+        <Box ref={setNodeRef} sx ={{...styling, height:tall}}>
+            <Typography variant='h6' style={{padding: '10px'}}>{props.title}</Typography>
+            {props.members.map((member) => (
+                <TeamItem id={member.id} name={member.name} experience={member.experience} team={member.team}/>
+            ))}
+        </Box>
+    );
+}

--- a/apps/applicant-tracking/src/components/TeamList/index.tsx
+++ b/apps/applicant-tracking/src/components/TeamList/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useState } from 'react';
+import React, { ReactNode, useState, useEffect } from 'react';
 import { useDroppable } from "@dnd-kit/core";
 import { Box, Typography } from '@mui/material';
 import { TeamItem } from './TeamItem';
@@ -26,13 +26,13 @@ export function TeamList (props: TeamListProperties){
     const styling = {
         display: 'flex', justifyContent: 'top center', alignItems: 'center', flexDirection:'column',
         borderRadius: 2, border: '1px solid black',
-        width: 300, margin:'10px'
+        width: 300, height: 70 + 50 * props.members.length, margin:'20px'
     }
 
-    const [tall, setTall] = useState(50); //eventually useful if height of the boxes need to be dynamic
+    //const [tall, setTall] = useState(50); //eventually useful if height of the boxes need to be dynamic
 
     return (
-        <Box ref={setNodeRef} sx ={{...styling, height:tall}}>
+        <Box ref={setNodeRef} sx ={styling}>
             <Typography variant='h6' style={{padding: '10px'}}>{props.title}</Typography>
             {props.members.map((member) => (
                 <TeamItem id={member.id} name={member.name} experience={member.experience} team={member.team}/>

--- a/apps/applicant-tracking/src/components/TeamList/index.tsx
+++ b/apps/applicant-tracking/src/components/TeamList/index.tsx
@@ -31,8 +31,6 @@ export function TeamList (props: TeamListProperties){
         bgcolor: isOver ? '#f4d9b7' : 'white',
     }
 
-    //const [tall, setTall] = useState(50); //eventually useful if height of the boxes need to be dynamic
-
     return (
         <Box ref={setNodeRef} sx ={styling}>
             <Typography variant='h6' style={{padding: '10px'}}>{props.title}</Typography>

--- a/apps/applicant-tracking/src/components/TeamList/index.tsx
+++ b/apps/applicant-tracking/src/components/TeamList/index.tsx
@@ -21,12 +21,14 @@ interface TeamListProperties{
 
 
 export function TeamList (props: TeamListProperties){
-    const {setNodeRef} = useDroppable({id: props.id})
+    const {isOver, setNodeRef} = useDroppable({id: props.id})
 
     const styling = {
         display: 'flex', justifyContent: 'top center', alignItems: 'center', flexDirection:'column',
-        borderRadius: 2, border: '1px solid black',
-        width: 300, height: 70 + 50 * props.members.length, margin:'20px'
+        borderRadius: 2,
+        width: 300, height: 70 + 50 * props.members.length, margin:'20px',
+        border: isOver ? '1px dashed orange' : '1px solid black',
+        bgcolor: isOver ? '#f4d9b7' : 'white',
     }
 
     //const [tall, setTall] = useState(50); //eventually useful if height of the boxes need to be dynamic


### PR DESCRIPTION
# Description
Styled the teams page and added teammate bar + drag and drop functionality
Make sure to drag the member onto the label of each team. Dragging to the list of members does nothing. Let me know if this should be changed for better intuitiveness. 

## Relevant issue(s)

#285 - Style Teams Page
#286 - Add Teammate Bar

## Questions
For some reason the code breaks if you add any two members to the same team in a row. If you add a member to a different team in between then its fine. No clue why. Its technically a bug but non breaking.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have assigned reviewers to this PR
