### PR TITLE
Fix History Filters

### DIFF
--- a/apps/applicant-tracking/src/app/applicants/history/page.tsx
+++ b/apps/applicant-tracking/src/app/applicants/history/page.tsx
@@ -4,6 +4,7 @@ import { LineChart } from '@mui/x-charts/LineChart';
 import Button from '@mui/material/Button'
 import Box from '@mui/material/Box';
 import { Circle } from '@mui/icons-material';
+import { HistoryFilter } from '@/components/HistoryFilters';
 
 const data = [{date: '2023', ap: 50, ac: 25, ret: 10}, {date: '2024', ap: 30, ac: 70, ret: 60}, {date: '2025', ap: 80, ac: 60, ret: 30}];
 const graphKeys = {
@@ -28,7 +29,14 @@ export default function HistoryPage() {
     <Typography variant='h4' align='center' style={{padding: '10px'}}>History</Typography>
     <Box sx={{ width: '95%', height: 5, bgcolor: 'orange', margin: 'auto'}} />
 
-    <div style={{display: 'flex', justifyContent: 'center', alignItems: 'center'}}>
+    <div style={{display: 'flex', justifyContent: 'center', alignItems: 'center', gap:'30px', padding:'20px'}}>
+      {/* Filters are Non Functional */}
+      <HistoryFilter id="LeftFilter"/>
+      <Typography sx={{padding:'20px'}}>To</Typography>
+      <HistoryFilter id="Rightfilter"/>
+    </div>
+
+    <div style={{display: 'flex', justifyContent: 'center', alignItems: 'center'}}> {/* Buttons currently have no functionality */}
       <Button variant='contained' startIcon={<Circle style={{fill: '#72b8cc'}}/>} sx={graphKeys}>Applications</Button>
       <Button variant='contained' startIcon={<Circle style={{fill: '#ab6563'}}/>} sx={graphKeys}>Admitted</Button>
       <Button variant='contained' startIcon={<Circle style={{fill: '#e3a457'}}/>} sx={graphKeys}>Retention</Button>
@@ -38,6 +46,8 @@ export default function HistoryPage() {
       xAxis={[{          
         dataKey: 'date',
         scaleType: 'point',
+        //min:{}
+        //max:{} link this to history filters & Change data format to include semesters
       }]}
       yAxis={[{
         min: 0,
@@ -60,8 +70,8 @@ export default function HistoryPage() {
         },
       ]}
       dataset={data}
-      width={500}
-      height={300}
+      width={600}
+      height={400}
     />
     </div>
     </>

--- a/apps/applicant-tracking/src/components/HistoryFilters/index.tsx
+++ b/apps/applicant-tracking/src/components/HistoryFilters/index.tsx
@@ -6,7 +6,11 @@ import MenuItem from '@mui/material/MenuItem';
 import FormControl from '@mui/material/FormControl';
 import Select, { SelectChangeEvent } from '@mui/material/Select';
 
-export default function BasicSelect() {
+interface FilterProps {
+  id: string;
+}
+
+export function HistoryFilter(props: FilterProps) {
   const [date, setDate] = React.useState('');
 
   const handleChange = (event: SelectChangeEvent) => {
@@ -16,10 +20,10 @@ export default function BasicSelect() {
   return (
     <Box sx={{ width: '140px'}}>
       <FormControl fullWidth>
-        <InputLabel id="HistoryRightFilterLabel">End Date</InputLabel>
+        <InputLabel id={props.id + "Label"}>End Date</InputLabel>
         <Select
-          labelId="HistoryRightFilterLabel"
-          id="HistoryRightFilter"
+          labelId={props.id + "Label"}
+          id={props.id}
           value={date}
           label="End Date"
           onChange={handleChange}


### PR DESCRIPTION
# Description
Consolidated Left and Right History components into one component that has an addressable ID. Added components to history page along with styling to accompany it.  

## Relevant issue(s)

#278 Add History Filters
#252 Add the Left History Year filter
#253 Create Right Filter on History Page

## Questions
At the time of implementing I didn't realize that somebody else had made their own branch implementing the history filters as well. They did it a different way then me so you might want to compare the two and see which you prefer. I don't think they have a pull request at the moment so you'll just have to find it in the 278 branch if you want to check.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have assigned reviewers to this PR
